### PR TITLE
Adjust deprecated curly braces string offset access

### DIFF
--- a/src/StateParser.php
+++ b/src/StateParser.php
@@ -178,7 +178,7 @@ class StateParser
     function scanCharacter()
     {
         if ($this->position < $this->length) {
-            return $this->rawtext{$this->position++};
+            return $this->rawtext[$this->position++];
         }
     }
 


### PR DESCRIPTION
This change silences a deprecation warning in PHP 7.4